### PR TITLE
Chinese remainder transform

### DIFF
--- a/cyclotomic_field/src/cyclotomic_ring/mod.rs
+++ b/cyclotomic_field/src/cyclotomic_ring/mod.rs
@@ -1,5 +1,32 @@
-mod sparse;
-mod dense;
 mod crt_basis;
+mod dense;
+mod sparse;
 
 use fields::Field;
+
+pub struct CRTDomain<F: Field> {
+    omega_powers: Vec<F>,
+}
+
+impl<F: Field> CRTDomain<F> {
+    pub fn new(prime: usize, prime_power: usize, rou: F, q: usize) -> Self {
+        let n = prime.pow(prime_power as u32);
+        assert_eq!(
+            (q - 1) / n % prime,
+            0,
+            "Field does not support powers of {}",
+            prime
+        );
+        let resize_power = (q - 1) / n;
+        let omega = rou.pow(resize_power as u128);
+        assert_eq!(omega.pow(n as u128), F::one(), "Omega^N != 1");
+        let mut current_omega_power = F::one();
+        let mut omega_powers = Vec::new();
+        for _ in 0..n {
+            omega_powers.push(current_omega_power);
+            current_omega_power = current_omega_power * omega;
+        }
+
+        CRTDomain { omega_powers }
+    }
+}


### PR DESCRIPTION
Includes
 Chinese Remainder Transform to use element wise multiplication of cyclotomics
TODO:
- [x] Invert omega powers in `to_power_basis`
- [x] Adapt sparse representation and naive CRT for sparse
- [ ] Use arkworks finite fields impl
- [x] Precompute omega powers
- [ ] Optimize `radixp_ntt`
- [ ] Precompute icrt matrices for prime = 5, 7, ...
- [ ] Add test to review crt algorithm, already tested [here](https://github.com/ivolkg/cyclotomic-math/blob/bf6deb05dae2c8b81bf1d3c2f0e0377d8cd16e0b/src/integer_mod_q/polynomial_ring_zq.rs#L139) 
- [ ] ~Add/Mul ops from reference~
- [ ] Parallelize