### PR TITLE
CCS matrix padding constraints removed

### DIFF
--- a/latticefold/src/arith.rs
+++ b/latticefold/src/arith.rs
@@ -101,8 +101,8 @@ impl<R: Ring> Arith<R> for CCS<R> {
 }
 
 impl<R: Ring> CCS<R> {
-    pub fn from_r1cs(r1cs: R1CS<R>) -> Self {
-        let m = r1cs.A.nrows();
+    pub fn from_r1cs(r1cs: R1CS<R>, W: usize) -> Self {
+        let m = W;
         let n = r1cs.A.ncols();
 
         CCS {
@@ -118,44 +118,6 @@ impl<R: Ring> CCS<R> {
             S: vec![vec![0, 1], vec![2]],
             c: vec![R::one(), R::one().neg()],
             M: vec![r1cs.A, r1cs.B, r1cs.C],
-        }
-    }
-
-    pub fn from_r1cs_with_padding(r1cs: R1CS<R>, W: usize) -> Self {
-        let mut m = r1cs.A.nrows();
-        let n = r1cs.A.ncols();
-
-        // TODO: too much cloning happens here. Avoid it in the future.
-        let extend = |mat: SparseMatrix<R>| -> SparseMatrix<R> {
-            let mut values: Vec<R> = mat.transpose().values().to_vec();
-            values.extend(vec![R::ZERO; (W - m) * n]);
-            let rows: Vec<Vec<R>> = values.chunks(n).map(|c| c.to_vec()).collect();
-
-            SparseMatrix::from(rows.as_slice())
-        };
-
-        // Pad with dummy constraints to have the number of constraints the same as W - the number of columns
-        // of the Ajtai matrix or, equivalently, the number of columns of the G gadget matrix
-        // (see Definition 4.3 in the paper).
-        let A = extend(r1cs.A);
-        let B = extend(r1cs.B);
-        let C = extend(r1cs.C);
-
-        m = W;
-
-        CCS {
-            m,
-            n,
-            l: r1cs.l,
-            s: log2(m) as usize,
-            s_prime: log2(n) as usize,
-            t: 3,
-            q: 2,
-            d: 2,
-
-            S: vec![vec![0, 1], vec![2]],
-            c: vec![R::one(), R::one().neg()],
-            M: vec![A, B, C],
         }
     }
 
@@ -286,7 +248,7 @@ pub mod tests {
 
     pub fn get_test_ccs<R: Ring>(W: usize) -> CCS<R> {
         let r1cs = get_test_r1cs::<R>();
-        CCS::<R>::from_r1cs_with_padding(r1cs, W)
+        CCS::<R>::from_r1cs(r1cs, W)
     }
     pub fn get_test_z<R: Ring>(input: usize) -> Vec<R> {
         r1cs_get_test_z(input)


### PR DESCRIPTION
I added padding with dummy constraints [here](https://github.com/NethermindEth/latticefold/pull/37). This introduced memory problems with large witnesses. I now realised the padding (mentioned in Definition 4.3) is redundant - the problem of having `Mz_mles` of the correct size to be able to evaluate `r` is actually handled already [here](https://github.com/NethermindEth/latticefold/blob/7980b88f81ad82e678b531950a903f5ff0b35a34/latticefold/src/utils/mle.rs#L89).

So it suffices just to set `m` correctly when instantiating the constraint matrix, the padding is redundant and is removed in this PR.

Without padding, there is no problem with huge witnesses (for example for witness of size `2**14`, with padding we got `2**14 x 2**14` matrix, while without padding it's only `num_of_constraints x 2**14`.