### PR TITLE
perf: Ajtai commit NTT dot product enhancement

### DIFF
--- a/latticefold/src/commitment/commitment_scheme.rs
+++ b/latticefold/src/commitment/commitment_scheme.rs
@@ -65,7 +65,6 @@ impl<const C: usize, const W: usize, NTT: SuitableRing> AjtaiCommitmentScheme<C,
         let mut commitment: Vec<NTT> = vec![NTT::zero(); C];
 
         for (i, row) in self.matrix.iter().enumerate() {
-            commitment[i] = NTT::zero();
             #[allow(clippy::op_ref)] // Allow `&f`, for Mul to be called with ref
             for j in 0..W {
                 commitment[i] += row[j] * &f[j];


### PR DESCRIPTION
Avoids creating intermediate NTT instances related with `map()` / `sum()`.
Reported +14% performance increase for the Ajtai bench.