### PR TITLE
Adds padding for folding of field extended fields

### DIFF
--- a/latticefold/src/nifs/folding.rs
+++ b/latticefold/src/nifs/folding.rs
@@ -89,7 +89,14 @@ impl<NTT: SuitableRing, T: TranscriptWithShortChallenges<NTT>> FoldingProver<NTT
                 w.f_hat
                     .iter()
                     .map(|f_hat_row| {
-                        DenseMultilinearExtension::from_evaluations_slice(log_m, f_hat_row)
+                        if 1 << log_m != f_hat_row.len() {
+                            let mut padded = Vec::with_capacity(1 << log_m);
+                            padded.extend_from_slice(f_hat_row);
+                            padded.resize(1 << log_m, NTT::zero());
+                            DenseMultilinearExtension::from_evaluations_slice(log_m, &padded)
+                        } else {
+                            DenseMultilinearExtension::from_evaluations_slice(log_m, f_hat_row)
+                        }
                     })
                     .collect()
             })


### PR DESCRIPTION
When folding fields that used some kind of field extension, I encountered a mismatch in vector lengths. This solves the issue by applying padding.