### PR TITLE
Compute the NTT/iNTT only once

### DIFF
--- a/latticefold/src/nifs/decomposition.rs
+++ b/latticefold/src/nifs/decomposition.rs
@@ -39,8 +39,10 @@ impl<NTT: SuitableRing, T: Transcript<NTT>> DecompositionProver<NTT, T>
         let log_m = ccs.s;
 
         let wit_s: Vec<Witness<NTT>> = {
-            let f_s = decompose_B_vec_into_k_vec::<NTT, P>(&wit.f);
-            f_s.into_iter().map(|f| Witness::from_f::<P>(f)).collect()
+            let f_s = decompose_B_vec_into_k_vec::<NTT, P>(&wit.f_coeff);
+            f_s.into_iter()
+                .map(|f| Witness::from_f_coeff::<P>(f))
+                .collect()
         };
 
         let mut cm_i_x_w = cm_i.x_w.clone();

--- a/latticefold/src/nifs/decomposition/tests.rs
+++ b/latticefold/src/nifs/decomposition/tests.rs
@@ -39,15 +39,14 @@ macro_rules! generate_decomposition_tests {
             const K: usize = $k;
         }
 
-        fn draw_ring_bellow_bound<const B: u128>(rng: &mut ThreadRng) -> RqNTT {
+        fn draw_ring_bellow_bound<const B: u128>(rng: &mut ThreadRng) -> RqPoly {
             let degree = <RqPoly as PolyRing>::dimension();
             let mut coeffs = Vec::with_capacity(degree);
             for _ in 0..degree {
                 let random_coeff = rng.gen_range(0..B);
                 coeffs.push(<RqPoly as PolyRing>::BaseRing::from(random_coeff));
             }
-            let coeff_repr = RqPoly::from(coeffs);
-            coeff_repr.into()
+            RqPoly::from(coeffs)
         }
 
         #[test]
@@ -103,7 +102,7 @@ macro_rules! generate_decomposition_tests {
             // Create a test vector
             const N: usize = 32;
             let mut rng = thread_rng();
-            let test_vector: Vec<RqNTT> = (0..N)
+            let test_vector: Vec<RqPoly> = (0..N)
                 .map(|_| draw_ring_bellow_bound::<{ PP::B }>(&mut rng))
                 .collect();
 
@@ -128,7 +127,7 @@ macro_rules! generate_decomposition_tests {
                 let decomp_i = decomposed.iter().map(|d_j| d_j[i]).collect::<Vec<_>>();
                 assert_eq!(
                     test_vector[i],
-                    recompose(&decomp_i, RqNTT::from(PP::B_SMALL as u128))
+                    recompose(&decomp_i, RqPoly::from(PP::B_SMALL as u128))
                 );
             }
         }
@@ -139,7 +138,7 @@ macro_rules! generate_decomposition_tests {
             const N: usize = 32;
             let mut rng = thread_rng();
             let test_vector: Vec<RqNTT> = (0..N)
-                .map(|_| draw_ring_bellow_bound::<{ PP::B }>(&mut rng))
+                .map(|_| draw_ring_bellow_bound::<{ PP::B }>(&mut rng).into())
                 .collect();
             let decomposed_and_composed_back =
                 decompose_big_vec_into_k_vec_and_compose_back::<RqNTT, PP>(&test_vector);

--- a/latticefold/src/nifs/decomposition/utils.rs
+++ b/latticefold/src/nifs/decomposition/utils.rs
@@ -40,19 +40,7 @@ pub(super) fn decompose_big_vec_into_k_vec_and_compose_back<
 
 /// Decompose a vector of norm B in its NTT form into DP::K small vectors.
 pub(super) fn decompose_B_vec_into_k_vec<NTT: SuitableRing, DP: DecompositionParams>(
-    x: &[NTT],
-) -> Vec<Vec<NTT>> {
-    // TODO: Measure time for coefficient representation conversion
-    let coeff_repr: Vec<NTT::CoefficientRepresentation> = x.iter().map(|&x| x.into()).collect();
-
-    // TODO: Measure time for decomposition
-    let res_coeffs =
-        decompose_balanced_vec(&coeff_repr, DP::B_SMALL as u128, Some(DP::K)).transpose();
-
-    let res = res_coeffs
-        .iter()
-        .map(|vec| vec.iter().map(|&x| x.into()).collect())
-        .collect();
-
-    res
+    x: &[NTT::CoefficientRepresentation],
+) -> Vec<Vec<NTT::CoefficientRepresentation>> {
+    decompose_balanced_vec(x, DP::B_SMALL as u128, Some(DP::K)).transpose()
 }

--- a/latticefold/src/nifs/linearization/structs.rs
+++ b/latticefold/src/nifs/linearization/structs.rs
@@ -1,5 +1,6 @@
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::marker::PhantomData;
+use cyclotomic_rings::rings::SuitableRing;
 
 use crate::{
     arith::{Witness, CCCS, CCS, LCCCS},
@@ -18,7 +19,7 @@ pub struct LinearizationProof<NTT: OverField> {
     pub u: Vec<NTT>,
 }
 
-pub trait LinearizationProver<NTT: OverField, T: Transcript<NTT>> {
+pub trait LinearizationProver<NTT: SuitableRing, T: Transcript<NTT>> {
     fn prove<const C: usize>(
         cm_i: &CCCS<C, NTT>,
         wit: &Witness<NTT>,


### PR DESCRIPTION
Adding `f_coeff`, the coefficient representation, to the witness. Since we need to compute it anyway let's compute it at the very initialisation of a witness struct. So that we can easily access it without recomputing. In particular, `decompose_B_vec_into_k_vec` would recompute the coefficient form of the witness.