### PR TITLE
Get rid of Pow2 tests

### DIFF
--- a/cyclotomic-rings/src/challenge_set.rs
+++ b/cyclotomic-rings/src/challenge_set.rs
@@ -3,10 +3,6 @@
 //!
 
 use error::ChallengeSetError;
-use lattirust_ring::{
-    cyclotomic_ring::models::pow2_debug::{Pow2CyclotomicPolyRing, Pow2CyclotomicPolyRingNTT},
-    zn::z_q::Zq,
-};
 
 use crate::rings::SuitableRing;
 
@@ -23,27 +19,4 @@ pub trait LatticefoldChallengeSet<R: SuitableRing> {
     fn short_challenge_from_random_bytes(
         bs: &[u8],
     ) -> Result<R::CoefficientRepresentation, ChallengeSetError>;
-}
-
-pub struct BinarySmallSet<const Q: u64, const N: usize>;
-
-impl<const Q: u64, const N: usize> LatticefoldChallengeSet<Pow2CyclotomicPolyRingNTT<Q, N>>
-    for BinarySmallSet<Q, N>
-where
-    Pow2CyclotomicPolyRingNTT<Q, N>:
-        SuitableRing<CoefficientRepresentation = Pow2CyclotomicPolyRing<Q, N>>,
-{
-    const BYTES_NEEDED: usize = N * 8;
-
-    fn short_challenge_from_random_bytes(
-        bs: &[u8],
-    ) -> Result<Pow2CyclotomicPolyRing<Q, N>, ChallengeSetError> {
-        if bs.len() != Self::BYTES_NEEDED {
-            return Err(ChallengeSetError::TooFewBytes(bs.len(), Self::BYTES_NEEDED));
-        }
-
-        Ok(Pow2CyclotomicPolyRing::from(
-            bs.iter().map(|&x| Zq::from(x)).collect::<Vec<_>>(),
-        ))
-    }
 }

--- a/cyclotomic-rings/src/rings.rs
+++ b/cyclotomic-rings/src/rings.rs
@@ -3,16 +3,12 @@
 //!
 
 use ark_crypto_primitives::sponge::{poseidon::PoseidonConfig, Absorb};
+use ark_ff::Field;
 use ark_ff::PrimeField;
-use ark_ff::{Field, Zero};
 use ark_std::ops::MulAssign;
 use lattirust_ring::{
     balanced_decomposition::Decompose,
-    cyclotomic_ring::{
-        models::pow2_debug::{Pow2CyclotomicPolyRing, Pow2CyclotomicPolyRingNTT},
-        CRT, ICRT,
-    },
-    zn::z_q::Zq,
+    cyclotomic_ring::{CRT, ICRT},
     Cyclotomic, OverField, PolyRing,
 };
 
@@ -77,41 +73,4 @@ where
 pub trait GetPoseidonParams<Fq: PrimeField> {
     /// Returns the associated Poseidon sponge configuration.
     fn get_poseidon_config() -> PoseidonConfig<Fq>;
-}
-
-pub struct Pow2Params<const Q: u64, const N: usize>;
-
-impl<const Q: u64, const N: usize> GetPoseidonParams<Zq<Q>> for Pow2Params<Q, N> {
-    fn get_poseidon_config() -> PoseidonConfig<Zq<Q>> {
-        PoseidonConfig {
-            full_rounds: 8, // Example values, adjust according to your needs
-            partial_rounds: 57,
-            alpha: 5,
-            ark: vec![vec![Zq::zero(); 3]; 8 + 57], // Adjust to actual ark parameters
-            mds: vec![vec![Zq::zero(); 3]; 3],      // Adjust to actual MDS matrix parameters
-            rate: 2,
-            capacity: 1,
-        }
-    }
-}
-
-impl<const Q: u64, const N: usize> SuitableRing for Pow2CyclotomicPolyRingNTT<Q, N> {
-    type CoefficientRepresentation = Pow2CyclotomicPolyRing<Q, N>;
-    type PoseidonParams = Pow2Params<Q, N>;
-}
-
-#[cfg(test)]
-mod tests {
-    use lattirust_ring::Ring;
-
-    use super::*;
-
-    #[test]
-    fn test_trait_implementation() {
-        fn takes_suitable_ring<R: SuitableRing>(_x: R) {}
-
-        let x: Pow2CyclotomicPolyRingNTT<17, 4> = Pow2CyclotomicPolyRingNTT::ZERO;
-
-        takes_suitable_ring(x);
-    }
 }

--- a/latticefold/src/arith.rs
+++ b/latticefold/src/arith.rs
@@ -327,11 +327,8 @@ pub mod tests {
 
     use super::*;
     use crate::arith::r1cs::{get_test_dummy_r1cs, get_test_r1cs, get_test_z as r1cs_get_test_z};
-    use cyclotomic_rings::rings::{GoldilocksRingNTT, GoldilocksRingPoly};
-    use lattirust_ring::cyclotomic_ring::models::{
-        goldilocks::{Fq, Fq3},
-        pow2_debug::Pow2CyclotomicPolyRingNTT,
-    };
+    use cyclotomic_rings::rings::{BabyBearRingNTT, GoldilocksRingNTT, GoldilocksRingPoly};
+    use lattirust_ring::cyclotomic_ring::models::goldilocks::{Fq, Fq3};
 
     pub fn get_test_ccs<R: Ring>(W: usize) -> CCS<R> {
         let r1cs = get_test_r1cs::<R>();
@@ -352,7 +349,7 @@ pub mod tests {
     /// Test that a basic CCS relation can be satisfied
     #[test]
     fn test_ccs_relation() {
-        let ccs = get_test_ccs::<Pow2CyclotomicPolyRingNTT<101u64, 64>>(4);
+        let ccs = get_test_ccs::<BabyBearRingNTT>(4);
         let z = get_test_z(3);
 
         ccs.check_relation(&z).unwrap();

--- a/latticefold/src/arith/r1cs.rs
+++ b/latticefold/src/arith/r1cs.rs
@@ -175,12 +175,13 @@ pub fn get_test_dummy_z_split<R: Ring, const X_LEN: usize, const WIT_LEN: usize>
 
 #[cfg(test)]
 pub mod tests {
+    use cyclotomic_rings::rings::FrogRingNTT;
+
     use super::*;
 
-    use lattirust_ring::cyclotomic_ring::models::pow2_debug::Pow2CyclotomicPolyRingNTT;
     #[test]
     fn test_check_relation() {
-        let r1cs = get_test_r1cs::<Pow2CyclotomicPolyRingNTT<101, 16>>();
+        let r1cs = get_test_r1cs::<FrogRingNTT>();
         let z = get_test_z(5);
 
         r1cs.check_relation(&z).unwrap();

--- a/latticefold/src/nifs/decomposition/tests/mod.rs
+++ b/latticefold/src/nifs/decomposition/tests/mod.rs
@@ -254,39 +254,6 @@ where
     }
 }
 
-mod pow2 {
-    use cyclotomic_rings::challenge_set::BinarySmallSet;
-    use lattirust_ring::cyclotomic_ring::models::pow2_debug::{
-        Pow2CyclotomicPolyRing, Pow2CyclotomicPolyRingNTT,
-    };
-
-    const Q: u64 = 17;
-    const N: usize = 8;
-    type RqNTT = Pow2CyclotomicPolyRingNTT<Q, N>;
-    type RqPoly = Pow2CyclotomicPolyRing<Q, N>;
-    type CS = BinarySmallSet<Q, N>;
-
-    #[test]
-    fn test_decomposition() {
-        super::test_decomposition::<RqNTT, CS>();
-    }
-
-    #[test]
-    fn test_decomposition_proof_serialization() {
-        super::test_decomposition_proof_serialization::<RqNTT, CS>();
-    }
-
-    #[test]
-    fn test_decompose_B_vec_into_k_vec() {
-        super::test_decompose_B_vec_into_k_vec::<RqNTT, RqPoly>();
-    }
-
-    #[test]
-    fn test_decompose_big_vec_into_k_vec_and_compose_back() {
-        super::test_decompose_big_vec_into_k_vec_and_compose_back::<RqNTT, RqPoly>();
-    }
-}
-
 mod stark {
     use crate::arith::r1cs::get_test_dummy_z_split;
     use crate::arith::tests::get_test_dummy_ccs;

--- a/latticefold/src/nifs/linearization/tests/mod.rs
+++ b/latticefold/src/nifs/linearization/tests/mod.rs
@@ -175,34 +175,6 @@ where
     );
 }
 
-mod tests_pow2 {
-    use cyclotomic_rings::challenge_set::BinarySmallSet;
-    use lattirust_ring::cyclotomic_ring::models::pow2_debug::Pow2CyclotomicPolyRingNTT;
-
-    const Q: u64 = 17; // Replace with an appropriate modulus
-    const N: usize = 8;
-
-    type RqNTT = Pow2CyclotomicPolyRingNTT<Q, N>;
-    #[test]
-    fn test_compute_ui() {
-        super::test_compute_ui::<RqNTT>();
-    }
-
-    #[test]
-    fn test_linearization_polynomial() {
-        super::test_linearization_polynomial::<RqNTT>();
-    }
-
-    #[test]
-    fn test_linearization() {
-        super::test_linearization::<RqNTT, BinarySmallSet<Q, N>>();
-    }
-    #[test]
-    fn test_linearization_proof_serialization() {
-        super::test_linearization_proof_serialization::<RqNTT, BinarySmallSet<Q, N>>();
-    }
-}
-
 mod tests_stark {
     use crate::arith::r1cs::get_test_dummy_z_split;
     use crate::arith::tests::get_test_dummy_ccs;

--- a/latticefold/src/utils/sumcheck.rs
+++ b/latticefold/src/utils/sumcheck.rs
@@ -190,33 +190,6 @@ mod tests {
         }
     }
 
-    mod pow2 {
-
-        use lattirust_ring::cyclotomic_ring::models::pow2_debug::Pow2CyclotomicPolyRingNTT;
-
-        use cyclotomic_rings::challenge_set::BinarySmallSet;
-        const Q: u64 = 17;
-        const N: usize = 8;
-        type RqNTT = Pow2CyclotomicPolyRingNTT<Q, N>;
-
-        type CS = BinarySmallSet<Q, N>;
-
-        #[test]
-        fn test_sumcheck() {
-            super::test_sumcheck::<RqNTT, CS>();
-        }
-
-        #[test]
-        fn test_sumcheck_proof_serialization() {
-            super::test_sumcheck_proof_serialization::<RqNTT, CS>();
-        }
-
-        #[test]
-        fn test_failing_sumcheck() {
-            super::test_failing_sumcheck::<RqNTT, CS>();
-        }
-    }
-
     mod stark {
         use cyclotomic_rings::rings::StarkChallengeSet;
         use lattirust_ring::cyclotomic_ring::models::stark_prime::RqNTT;


### PR DESCRIPTION
The pow2 rings were used for testing at the very early stage of the project. There's no much point in testing them now as they won't be used in any real-life code. 