### PR TITLE
Add `zlib` as an allowed license

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -34,6 +34,7 @@ allow = [
     "BSD-3-Clause",
     "BSD-2-Clause",
     "Unicode-DFS-2016",
+    "Zlib",
 ]
 confidence-threshold = 0.8
 # TODO remove this license clarifications after the lattirust status and license are clarified


### PR DESCRIPTION
Allows the permissible [`zlib` license](https://github.com/orlp/foldhash?tab=Zlib-1-ov-file#readme), employed by `foldhash`, a dependency of `hashbrown`.