### PR TITLE
Use `ark_std::test_rng()`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,7 +444,6 @@ dependencies = [
  "lattirust-ring",
  "num-bigint",
  "rand",
- "rand_chacha",
  "thiserror",
 ]
 
@@ -655,7 +654,6 @@ dependencies = [
  "num-traits",
  "paste",
  "rand",
- "rand_chacha",
  "rayon",
  "thiserror",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ lattirust-poly = { git = "ssh://git@github.com/NethermindEth/lattirust.git", bra
 lattirust-ring = { git = "ssh://git@github.com/NethermindEth/lattirust.git", branch = "main", default-features = false }
 num-bigint = { version = "0.4.5", default-features = false }
 rand = { version = "0.8.5", default-features = false }
-rand_chacha = { version = "0.3.1", default-features = false }
 thiserror = { version = "2.0.3", default-features = false }
 
 [workspace.metadata.docs.rs]

--- a/cyclotomic-rings/Cargo.toml
+++ b/cyclotomic-rings/Cargo.toml
@@ -10,12 +10,12 @@ ark-std = { workspace = true }
 ark-crypto-primitives = { workspace = true }
 num-bigint = { workspace = true }
 rand = { workspace = true }
-rand_chacha = { workspace = true }
 lattirust-linear-algebra = { workspace = true }
 lattirust-poly = { workspace = true }
 lattirust-ring = { workspace = true }
 thiserror = { workspace = true }
 
 [features]
-default = ["std"]
+default = [ "std" ]
 std = []
+getrandom = [ "ark-std/getrandom" ]

--- a/cyclotomic-rings/src/rotation.rs
+++ b/cyclotomic-rings/src/rotation.rs
@@ -108,15 +108,13 @@ pub fn rot_lin_combination<R: SuitableRing>(
 mod tests {
     use ark_ff::UniformRand;
     use lattirust_ring::cyclotomic_ring::models::goldilocks::{Fq, Fq3};
-    use rand::SeedableRng;
-    use rand_chacha::ChaCha8Rng;
 
     use super::*;
     use crate::rings::{GoldilocksRingNTT, GoldilocksRingPoly};
 
     #[test]
     fn test_rot_sum_with_coeffs() {
-        let mut rng = ChaCha8Rng::seed_from_u64(0);
+        let mut rng = ark_std::test_rng();
         let a = GoldilocksRingPoly::rand(&mut rng);
         let b = GoldilocksRingPoly::rand(&mut rng);
 
@@ -139,7 +137,7 @@ mod tests {
 
     #[test]
     fn test_rot_sum_with_ring_elems() {
-        let mut rng = ChaCha8Rng::seed_from_u64(0);
+        let mut rng = ark_std::test_rng();
 
         let a = GoldilocksRingPoly::rand(&mut rng);
         let b: Vec<GoldilocksRingPoly> = (0..Fq3::extension_degree())

--- a/latticefold/Cargo.toml
+++ b/latticefold/Cargo.toml
@@ -16,7 +16,6 @@ lattirust-ring = { workspace = true }
 num-traits = { version = "0.2.19", default-features = false }
 paste = "1.0.15"
 rand = { workspace = true }
-rand_chacha = { workspace = true }
 thiserror = { workspace = true }
 num-bigint = { workspace = true }
 rayon = { version = "1.10.0", optional = true }
@@ -31,7 +30,8 @@ parallel = [
     "lattirust-linear-algebra/parallel",
     "lattirust-poly/parallel",
     "lattirust-ring/parallel",
- ]
+]
+getrandom = [ "ark-std/getrandom" ]
 
 # dev-only
 dhat-heap = []

--- a/latticefold/benches/ajtai.rs
+++ b/latticefold/benches/ajtai.rs
@@ -11,8 +11,6 @@ use cyclotomic_rings::rings::{
 };
 use latticefold::commitment::AjtaiCommitmentScheme;
 use lattirust_ring::cyclotomic_ring::{CRT, ICRT};
-mod utils;
-use crate::utils::rng;
 use std::fmt::Debug;
 
 fn ajtai_benchmark<
@@ -22,10 +20,11 @@ fn ajtai_benchmark<
 >(
     group: &mut criterion::BenchmarkGroup<criterion::measurement::WallTime>,
 ) {
-    let witness: Vec<R> = (0..W).map(|_| R::rand(&mut rng())).collect();
+    let mut rng = ark_std::test_rng();
+    let witness: Vec<R> = (0..W).map(|_| R::rand(&mut rng)).collect();
     let witness_2 = witness.clone();
     let witness_3 = witness.clone();
-    let ajtai_data: AjtaiCommitmentScheme<C, W, R> = AjtaiCommitmentScheme::rand(&mut rng());
+    let ajtai_data: AjtaiCommitmentScheme<C, W, R> = AjtaiCommitmentScheme::rand(&mut rng);
 
     group.bench_with_input(
         BenchmarkId::new("CommitNTT", format!("C={}, W={}", C, W)),

--- a/latticefold/benches/utils.rs
+++ b/latticefold/benches/utils.rs
@@ -7,19 +7,6 @@ use latticefold::commitment::AjtaiCommitmentScheme;
 use latticefold::decomposition_parameters::DecompositionParams;
 
 #[allow(dead_code)]
-pub fn rng() -> impl rand::Rng {
-    #[cfg(feature = "std")]
-    {
-        rand::thread_rng()
-    }
-    #[cfg(not(feature = "std"))]
-    {
-        use rand::SeedableRng;
-        rand_chacha::ChaCha8Rng::seed_from_u64(0)
-    }
-}
-
-#[allow(dead_code)]
 pub fn wit_and_ccs_gen<
     const X_LEN: usize,
     const C: usize, // rows
@@ -35,6 +22,8 @@ pub fn wit_and_ccs_gen<
     CCS<R>,
     AjtaiCommitmentScheme<C, W, R>,
 ) {
+    let mut rng = ark_std::test_rng();
+
     let new_r1cs_rows = if P::L == 1 && (WIT_LEN > 0 && (WIT_LEN & (WIT_LEN - 1)) == 0) {
         r1cs_rows - 2
     } else {
@@ -50,7 +39,7 @@ pub fn wit_and_ccs_gen<
         Err(e) => println!("R1CS invalid: {:?}", e),
     }
 
-    let scheme: AjtaiCommitmentScheme<C, W, R> = AjtaiCommitmentScheme::rand(&mut rng());
+    let scheme: AjtaiCommitmentScheme<C, W, R> = AjtaiCommitmentScheme::rand(&mut rng);
     let wit: Witness<R> = Witness::from_w_ccs::<P>(w_ccs);
 
     let cm_i: CCCS<C, R> = CCCS {

--- a/latticefold/src/arith.rs
+++ b/latticefold/src/arith.rs
@@ -335,8 +335,6 @@ impl<const C: usize, R: Ring> Instance<R> for LCCCS<C, R> {
 #[cfg(test)]
 pub mod tests {
     use ark_ff::{One, Zero};
-    use rand::SeedableRng;
-    use rand_chacha::ChaCha8Rng;
 
     use super::*;
     use crate::{
@@ -433,7 +431,7 @@ pub mod tests {
 
     #[test]
     fn test_from_w_ccs() {
-        let mut rng = ChaCha8Rng::seed_from_u64(0);
+        let mut rng = ark_std::test_rng();
 
         let random_witness =
             Witness::<GoldilocksRingNTT>::rand::<_, GoldilocksDP>(&mut rng, WIT_LEN);
@@ -445,7 +443,7 @@ pub mod tests {
 
     #[test]
     fn test_from_f() {
-        let mut rng = ChaCha8Rng::seed_from_u64(0);
+        let mut rng = ark_std::test_rng();
 
         let random_witness = Witness::<BabyBearRingNTT>::rand::<_, BabyBearDP>(&mut rng, WIT_LEN);
         let recreated_witness = Witness::from_f::<BabyBearDP>(random_witness.f.clone());
@@ -456,7 +454,7 @@ pub mod tests {
 
     #[test]
     fn test_from_f_coeff() {
-        let mut rng = ChaCha8Rng::seed_from_u64(0);
+        let mut rng = ark_std::test_rng();
 
         let random_witness = Witness::<StarkRingNTT>::rand::<_, StarkDP>(&mut rng, WIT_LEN);
         let recreated_witness = Witness::from_f_coeff::<StarkDP>(random_witness.f_coeff.clone());

--- a/latticefold/src/nifs/decomposition/tests/mod.rs
+++ b/latticefold/src/nifs/decomposition/tests/mod.rs
@@ -1,7 +1,6 @@
 use cyclotomic_rings::{challenge_set::LatticefoldChallengeSet, rings::SuitableRing};
 use lattirust_poly::mle::DenseMultilinearExtension;
-use rand::{Rng, SeedableRng};
-use rand_chacha::ChaCha8Rng;
+use rand::Rng;
 
 use crate::nifs::linearization::utils::compute_u;
 use crate::{
@@ -28,7 +27,7 @@ where
     CS: LatticefoldChallengeSet<RqNTT>,
     DP: DecompositionParams,
 {
-    let mut rng = ChaCha8Rng::seed_from_u64(0);
+    let mut rng = ark_std::test_rng();
     let input: usize = rng.gen_range(1..101);
     let ccs = get_test_ccs(W);
     let log_m = ccs.s;
@@ -122,8 +121,6 @@ mod stark {
     use crate::transcript::poseidon::PoseidonTranscript;
     use cyclotomic_rings::rings::StarkChallengeSet;
     use lattirust_ring::cyclotomic_ring::models::stark_prime::RqNTT;
-    use rand::SeedableRng;
-    use rand_chacha::ChaCha8Rng;
 
     type CS = StarkChallengeSet;
     const WIT_LEN: usize = 4;
@@ -146,7 +143,7 @@ mod stark {
         let r1cs_rows_size = X_LEN + WIT_LEN + 1; // Let's have a square matrix
         let ccs = get_test_dummy_ccs::<R, X_LEN, WIT_LEN, W>(r1cs_rows_size);
         let (_, x_ccs, w_ccs) = get_test_dummy_z_split::<R, X_LEN, WIT_LEN>();
-        let mut rng = ChaCha8Rng::seed_from_u64(0);
+        let mut rng = ark_std::test_rng();
         let scheme = AjtaiCommitmentScheme::rand(&mut rng);
         let wit = Witness::from_w_ccs::<DP>(w_ccs);
 

--- a/latticefold/src/nifs/decomposition/utils.rs
+++ b/latticefold/src/nifs/decomposition/utils.rs
@@ -59,8 +59,7 @@ mod tests {
         },
         PolyRing,
     };
-    use rand::{Rng, SeedableRng};
-    use rand_chacha::ChaCha8Rng;
+    use rand::Rng;
 
     use crate::{
         ark_base::*,
@@ -89,7 +88,7 @@ mod tests {
     {
         // Create a test vector
         const N: usize = 32;
-        let mut rng = ChaCha8Rng::seed_from_u64(0);
+        let mut rng = ark_std::test_rng();
         let test_vector: Vec<RqPoly> = (0..N)
             .map(|_| draw_ring_below_bound::<RqPoly, { DP::B }>(&mut rng))
             .collect();
@@ -164,7 +163,7 @@ mod tests {
     {
         // Create a test vector
         const N: usize = 32;
-        let mut rng = ChaCha8Rng::seed_from_u64(0);
+        let mut rng = ark_std::test_rng();
         let test_vector: Vec<RqNTT> = (0..N)
             .map(|_| draw_ring_below_bound::<RqPoly, { DP::B }>(&mut rng).crt())
             .collect();

--- a/latticefold/src/nifs/folding.rs
+++ b/latticefold/src/nifs/folding.rs
@@ -339,8 +339,6 @@ impl<NTT: SuitableRing, T: TranscriptWithShortChallenges<NTT>> FoldingVerifier<N
 mod tests {
     use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Compress, Validate};
     use ark_std::io::Cursor;
-    use rand::SeedableRng;
-    use rand_chacha::ChaCha8Rng;
 
     use crate::ark_base::*;
     use crate::nifs::folding::FoldingProof;
@@ -375,7 +373,7 @@ mod tests {
 
         let ccs = get_test_ccs::<R>(W);
         let (_, x_ccs, w_ccs) = get_test_z_split::<R>(3);
-        let mut rng = ChaCha8Rng::seed_from_u64(0);
+        let mut rng = ark_std::test_rng();
         let scheme = AjtaiCommitmentScheme::rand(&mut rng);
         let wit: Witness<R> = Witness::from_w_ccs::<DPL1>(w_ccs);
         let cm_i: CCCS<4, R> = CCCS {
@@ -447,7 +445,7 @@ mod tests {
 
         let ccs = get_test_ccs::<R>(W);
         let (_, x_ccs, w_ccs) = get_test_z_split::<R>(3);
-        let mut rng = ChaCha8Rng::seed_from_u64(0);
+        let mut rng = ark_std::test_rng();
         let scheme = AjtaiCommitmentScheme::rand(&mut rng);
         let wit: Witness<R> = Witness::from_w_ccs::<DPL1>(w_ccs.clone());
         let cm_i: CCCS<4, R> = CCCS {
@@ -507,7 +505,7 @@ mod tests {
 
         let ccs = get_test_ccs::<R>(W);
         let (_, x_ccs, w_ccs) = get_test_z_split::<R>(3);
-        let mut rng = ChaCha8Rng::seed_from_u64(0);
+        let mut rng = ark_std::test_rng();
         let scheme = AjtaiCommitmentScheme::rand(&mut rng);
         let wit: Witness<R> = Witness::from_w_ccs::<DPL1>(w_ccs);
         let cm_i: CCCS<4, R> = CCCS {
@@ -579,8 +577,6 @@ mod tests {
 mod tests_goldilocks {
     use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Compress, Validate};
     use ark_std::io::Cursor;
-    use rand::SeedableRng;
-    use rand_chacha::ChaCha8Rng;
 
     use crate::ark_base::*;
     use crate::nifs::folding::FoldingProof;
@@ -615,7 +611,7 @@ mod tests_goldilocks {
 
         let ccs = get_test_ccs::<R>(W);
         let (_, x_ccs, w_ccs) = get_test_z_split::<R>(3);
-        let mut rng = ChaCha8Rng::seed_from_u64(0);
+        let mut rng = ark_std::test_rng();
         let scheme = AjtaiCommitmentScheme::rand(&mut rng);
         let wit: Witness<R> = Witness::from_w_ccs::<DPL1>(w_ccs);
         let cm_i: CCCS<4, R> = CCCS {
@@ -687,7 +683,7 @@ mod tests_goldilocks {
 
         let ccs = get_test_ccs::<R>(W);
         let (_, x_ccs, w_ccs) = get_test_z_split::<R>(3);
-        let mut rng = ChaCha8Rng::seed_from_u64(0);
+        let mut rng = ark_std::test_rng();
         let scheme = AjtaiCommitmentScheme::rand(&mut rng);
         let wit: Witness<R> = Witness::from_w_ccs::<DPL1>(w_ccs.clone());
         let cm_i: CCCS<4, R> = CCCS {
@@ -747,7 +743,7 @@ mod tests_goldilocks {
 
         let ccs = get_test_ccs::<R>(W);
         let (_, x_ccs, w_ccs) = get_test_z_split::<R>(3);
-        let mut rng = ChaCha8Rng::seed_from_u64(0);
+        let mut rng = ark_std::test_rng();
         let scheme = AjtaiCommitmentScheme::rand(&mut rng);
         let wit: Witness<R> = Witness::from_w_ccs::<DPL1>(w_ccs);
         let cm_i: CCCS<4, R> = CCCS {
@@ -820,8 +816,6 @@ mod tests_stark {
     use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Compress, Validate};
     use ark_std::io::Cursor;
     use lattirust_ring::cyclotomic_ring::models::stark_prime::RqNTT;
-    use rand::SeedableRng;
-    use rand_chacha::ChaCha8Rng;
 
     use crate::arith::tests::get_test_dummy_ccs;
     use crate::ark_base::*;
@@ -869,7 +863,7 @@ mod tests_stark {
 
         let ccs = get_test_dummy_ccs::<R, X_LEN, WIT_LEN, W>(r1cs_rows_size);
         let (_, x_ccs, w_ccs) = get_test_dummy_z_split::<R, X_LEN, WIT_LEN>();
-        let mut rng = ChaCha8Rng::seed_from_u64(0);
+        let mut rng = ark_std::test_rng();
         let scheme = AjtaiCommitmentScheme::rand(&mut rng);
 
         let wit = Witness::from_w_ccs::<StarkFoldingDP>(w_ccs);
@@ -964,7 +958,7 @@ mod tests_stark {
 
         let ccs = get_test_dummy_ccs::<R, X_LEN, WIT_LEN, W>(r1cs_rows_size);
         let (_, x_ccs, w_ccs) = get_test_dummy_z_split::<R, X_LEN, WIT_LEN>();
-        let mut rng = ChaCha8Rng::seed_from_u64(0);
+        let mut rng = ark_std::test_rng();
         let scheme = AjtaiCommitmentScheme::rand(&mut rng);
 
         let wit = Witness::from_w_ccs::<StarkFoldingDP>(w_ccs);

--- a/latticefold/src/nifs/linearization/tests/mod.rs
+++ b/latticefold/src/nifs/linearization/tests/mod.rs
@@ -21,12 +21,11 @@ use lattirust_poly::{
     polynomials::{build_eq_x_r, RefCounter, VirtualPolynomial},
 };
 use lattirust_ring::OverField;
-use rand::SeedableRng;
-use rand_chacha::ChaCha8Rng;
 
 fn test_compute_ui<R: OverField>() {
-    let mut mles = Vec::with_capacity(10);
     let mut rng = ark_std::test_rng();
+
+    let mut mles = Vec::with_capacity(10);
 
     for _i in 0..10 {
         let evals: Vec<R> = (0..8).map(|_| R::rand(&mut rng)).collect();
@@ -110,12 +109,13 @@ where
     RqNTT: OverField + SuitableRing,
     CS: LatticefoldChallengeSet<RqNTT>,
 {
+    let mut rng = ark_std::test_rng();
+
     const WIT_LEN: usize = 4; // 4 is the length of witness in this (Vitalik's) example
     const W: usize = WIT_LEN * DP::L; // the number of columns of the Ajtai matrix
 
     let ccs = get_test_ccs::<RqNTT>(W);
     let (_, x_ccs, w_ccs) = get_test_z_split::<RqNTT>(3);
-    let mut rng = ChaCha8Rng::seed_from_u64(0);
     let scheme = AjtaiCommitmentScheme::rand(&mut rng);
 
     let wit: Witness<RqNTT> = Witness::from_w_ccs::<DP>(w_ccs);
@@ -189,8 +189,6 @@ mod tests_stark {
     use crate::transcript::poseidon::PoseidonTranscript;
     use cyclotomic_rings::rings::StarkChallengeSet;
     use lattirust_ring::cyclotomic_ring::models::stark_prime::RqNTT;
-    use rand::SeedableRng;
-    use rand_chacha::ChaCha8Rng;
 
     #[test]
     fn test_compute_ui() {
@@ -213,6 +211,8 @@ mod tests_stark {
 
     #[test]
     fn test_dummy_linearization() {
+        let mut rng = ark_std::test_rng();
+
         type R = RqNTT;
         type CS = StarkChallengeSet;
         type T = PoseidonTranscript<R, CS>;
@@ -225,7 +225,6 @@ mod tests_stark {
 
         let ccs = get_test_dummy_ccs::<R, X_LEN, WIT_LEN, W>(r1cs_rows_size);
         let (_, x_ccs, w_ccs) = get_test_dummy_z_split::<R, X_LEN, WIT_LEN>();
-        let mut rng = ChaCha8Rng::seed_from_u64(0);
         let scheme = AjtaiCommitmentScheme::rand(&mut rng);
 
         let wit = Witness::from_w_ccs::<StarkDP>(w_ccs);


### PR DESCRIPTION
Ark provides a `test_rng()` fn which already works in both `std` and in `no-std`.
Added a feature `getrandom` which enables better seeding options.
`thread_rng()` is employed if both `std` and `getrandom` features are enabled.