### PR TITLE
Move subprotocols traits to respective main files

### DIFF
--- a/latticefold/src/nifs/decomposition.rs
+++ b/latticefold/src/nifs/decomposition.rs
@@ -31,6 +31,32 @@ mod tests;
 
 mod utils;
 
+pub trait DecompositionProver<NTT: SuitableRing, T: Transcript<NTT>> {
+    fn prove<const W: usize, const C: usize, P: DecompositionParams>(
+        cm_i: &LCCCS<C, NTT>,
+        wit: &Witness<NTT>,
+        transcript: &mut impl Transcript<NTT>,
+        ccs: &CCS<NTT>,
+        scheme: &AjtaiCommitmentScheme<C, W, NTT>,
+    ) -> Result<
+        (
+            Vec<LCCCS<C, NTT>>,
+            Vec<Witness<NTT>>,
+            DecompositionProof<C, NTT>,
+        ),
+        DecompositionError,
+    >;
+}
+
+pub trait DecompositionVerifier<NTT: OverField, T: Transcript<NTT>> {
+    fn verify<const C: usize, P: DecompositionParams>(
+        cm_i: &LCCCS<C, NTT>,
+        proof: &DecompositionProof<C, NTT>,
+        transcript: &mut impl Transcript<NTT>,
+        ccs: &CCS<NTT>,
+    ) -> Result<Vec<LCCCS<C, NTT>>, DecompositionError>;
+}
+
 impl<NTT: SuitableRing, T: Transcript<NTT>> DecompositionProver<NTT, T>
     for LFDecompositionProver<NTT, T>
 {

--- a/latticefold/src/nifs/decomposition/structs.rs
+++ b/latticefold/src/nifs/decomposition/structs.rs
@@ -1,18 +1,9 @@
 #![allow(non_snake_case, clippy::upper_case_acronyms)]
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::marker::PhantomData;
-use lattirust_ring::{OverField, Ring};
+use lattirust_ring::Ring;
 
-use crate::{
-    arith::{Witness, CCS, LCCCS},
-    ark_base::*,
-    commitment::AjtaiCommitmentScheme,
-    commitment::Commitment,
-    decomposition_parameters::DecompositionParams,
-    nifs::error::DecompositionError,
-    transcript::Transcript,
-};
-use cyclotomic_rings::rings::SuitableRing;
+use crate::{ark_base::*, commitment::Commitment};
 
 /// The proof structure of the decomposition subprotocol.
 #[derive(Clone, Debug, PartialEq, CanonicalSerialize, CanonicalDeserialize)]
@@ -43,32 +34,6 @@ pub struct DecompositionProof<const C: usize, NTT: Ring> {
     pub x_s: Vec<Vec<NTT>>,
     /// Commitments to the decomposed witnesses.
     pub y_s: Vec<Commitment<C, NTT>>,
-}
-
-pub trait DecompositionProver<NTT: SuitableRing, T: Transcript<NTT>> {
-    fn prove<const W: usize, const C: usize, P: DecompositionParams>(
-        cm_i: &LCCCS<C, NTT>,
-        wit: &Witness<NTT>,
-        transcript: &mut impl Transcript<NTT>,
-        ccs: &CCS<NTT>,
-        scheme: &AjtaiCommitmentScheme<C, W, NTT>,
-    ) -> Result<
-        (
-            Vec<LCCCS<C, NTT>>,
-            Vec<Witness<NTT>>,
-            DecompositionProof<C, NTT>,
-        ),
-        DecompositionError,
-    >;
-}
-
-pub trait DecompositionVerifier<NTT: OverField, T: Transcript<NTT>> {
-    fn verify<const C: usize, P: DecompositionParams>(
-        cm_i: &LCCCS<C, NTT>,
-        proof: &DecompositionProof<C, NTT>,
-        transcript: &mut impl Transcript<NTT>,
-        ccs: &CCS<NTT>,
-    ) -> Result<Vec<LCCCS<C, NTT>>, DecompositionError>;
 }
 
 pub struct LFDecompositionProver<NTT, T> {

--- a/latticefold/src/nifs/folding.rs
+++ b/latticefold/src/nifs/folding.rs
@@ -36,6 +36,24 @@ pub use structs::*;
 
 mod structs;
 
+pub trait FoldingProver<NTT: SuitableRing, T: TranscriptWithShortChallenges<NTT>> {
+    fn prove<const C: usize, P: DecompositionParams>(
+        cm_i_s: &[LCCCS<C, NTT>],
+        w_s: Vec<Witness<NTT>>,
+        transcript: &mut impl TranscriptWithShortChallenges<NTT>,
+        ccs: &CCS<NTT>,
+    ) -> Result<(LCCCS<C, NTT>, Witness<NTT>, FoldingProof<NTT>), FoldingError<NTT>>;
+}
+
+pub trait FoldingVerifier<NTT: SuitableRing, T: TranscriptWithShortChallenges<NTT>> {
+    fn verify<const C: usize, P: DecompositionParams>(
+        cm_i_s: &[LCCCS<C, NTT>],
+        proof: &FoldingProof<NTT>,
+        transcript: &mut impl TranscriptWithShortChallenges<NTT>,
+        ccs: &CCS<NTT>,
+    ) -> Result<LCCCS<C, NTT>, FoldingError<NTT>>;
+}
+
 fn prepare_public_output<const C: usize, NTT: SuitableRing>(
     r_0: Vec<NTT>,
     v_0: Vec<NTT>,

--- a/latticefold/src/nifs/folding/structs.rs
+++ b/latticefold/src/nifs/folding/structs.rs
@@ -1,12 +1,7 @@
-use crate::arith::{Witness, CCS, LCCCS};
 use crate::ark_base::Vec;
-use crate::decomposition_parameters::DecompositionParams;
-use crate::nifs::error::FoldingError;
-use crate::transcript::TranscriptWithShortChallenges;
 use crate::utils::sumcheck;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::marker::PhantomData;
-use cyclotomic_rings::rings::SuitableRing;
 use lattirust_ring::OverField;
 
 #[derive(Clone, Debug, PartialEq, CanonicalSerialize, CanonicalDeserialize)]
@@ -16,24 +11,6 @@ pub struct FoldingProof<NTT: OverField> {
     // Step 3
     pub theta_s: Vec<Vec<NTT>>,
     pub eta_s: Vec<Vec<NTT>>,
-}
-
-pub trait FoldingProver<NTT: SuitableRing, T: TranscriptWithShortChallenges<NTT>> {
-    fn prove<const C: usize, P: DecompositionParams>(
-        cm_i_s: &[LCCCS<C, NTT>],
-        w_s: Vec<Witness<NTT>>,
-        transcript: &mut impl TranscriptWithShortChallenges<NTT>,
-        ccs: &CCS<NTT>,
-    ) -> Result<(LCCCS<C, NTT>, Witness<NTT>, FoldingProof<NTT>), FoldingError<NTT>>;
-}
-
-pub trait FoldingVerifier<NTT: SuitableRing, T: TranscriptWithShortChallenges<NTT>> {
-    fn verify<const C: usize, P: DecompositionParams>(
-        cm_i_s: &[LCCCS<C, NTT>],
-        proof: &FoldingProof<NTT>,
-        transcript: &mut impl TranscriptWithShortChallenges<NTT>,
-        ccs: &CCS<NTT>,
-    ) -> Result<LCCCS<C, NTT>, FoldingError<NTT>>;
 }
 
 pub struct LFFoldingProver<NTT, T> {

--- a/latticefold/src/nifs/linearization/structs.rs
+++ b/latticefold/src/nifs/linearization/structs.rs
@@ -1,15 +1,7 @@
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::marker::PhantomData;
 
-use cyclotomic_rings::rings::SuitableRing;
-
-use crate::{
-    arith::{Witness, CCCS, CCS, LCCCS},
-    ark_base::*,
-    nifs::error::LinearizationError,
-    transcript::Transcript,
-    utils::sumcheck,
-};
+use crate::{ark_base::*, utils::sumcheck};
 
 use lattirust_ring::OverField;
 
@@ -43,59 +35,6 @@ pub struct LinearizationProof<NTT: OverField> {
     ///
     /// Sent in the step 3 of linearization subprotocol.
     pub u: Vec<NTT>,
-}
-
-/// Prover for the linearization subprotocol
-pub trait LinearizationProver<NTT: SuitableRing, T: Transcript<NTT>> {
-    /// Generates a proof for the linearization subprotocol
-    ///
-    /// # Arguments
-    ///
-    /// * `cm_i` - A reference to a committed CCS statement to be linearized, i.e. a CCCS<C, NTT>.
-    /// * `wit` - A reference to a CCS witness for the statement cm_i.
-    /// * `transcript` - A mutable reference to a sponge for generating NI challenges.
-    /// * `ccs` - A reference to a Customizable Constraint System circuit representation.
-    ///
-    /// # Returns
-    ///
-    /// On success, returns a tuple `(LCCCS<C, NTT>, LinearizationProof<NTT>)` where:
-    ///   * `LCCCS<C, NTT>` is a linearized version of the CCS witness commitment.
-    ///   * `LinearizationProof<NTT>` is a proof that the linearization subprotocol was executed correctly.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if asked to evaluate MLEs with incorrect number of variables
-    ///
-    fn prove<const C: usize>(
-        cm_i: &CCCS<C, NTT>,
-        wit: &Witness<NTT>,
-        transcript: &mut impl Transcript<NTT>,
-        ccs: &CCS<NTT>,
-    ) -> Result<(LCCCS<C, NTT>, LinearizationProof<NTT>), LinearizationError<NTT>>;
-}
-
-/// Verifier for the linearization subprotocol.
-pub trait LinearizationVerifier<NTT: OverField, T: Transcript<NTT>> {
-    /// Verifies a proof for the linearization subprotocol.
-    ///
-    /// # Arguments
-    ///
-    /// * `cm_i` - A reference to a `CCCS<C, NTT>`, which represents a CCS statement and a commitment to a witness.
-    /// * `proof` - A reference to a `LinearizationProof<NTT>` containing the linearization proof.
-    /// * `transcript` - A mutable reference to a sponge for generating NI challenges.
-    /// * `ccs` - A reference to a Customizable Constraint System instance used in the protocol.
-    ///
-    /// # Returns
-    ///
-    /// * `Ok(LCCCS<C, NTT>)` - On success, returns a linearized version of the CCS witness commitment.
-    /// * `Err(LinearizationError<NTT>)` - If verification fails, returns a `LinearizationError<NTT>`.
-    ///
-    fn verify<const C: usize>(
-        cm_i: &CCCS<C, NTT>,
-        proof: &LinearizationProof<NTT>,
-        transcript: &mut impl Transcript<NTT>,
-        ccs: &CCS<NTT>,
-    ) -> Result<LCCCS<C, NTT>, LinearizationError<NTT>>;
 }
 
 /// The LatticeFold prover


### PR DESCRIPTION
Removes subprotocols traits from their `structs.rs` files.