### PR TITLE
Ignore more 0's in g2_i sumcheck

### DIFF
--- a/latticefold/src/nifs/folding/utils.rs
+++ b/latticefold/src/nifs/folding/utils.rs
@@ -201,7 +201,9 @@ pub(crate) fn sumcheck_polynomial_comb_fn<NTT: SuitableRing, P: DecompositionPar
             let f_i = vals[5 + i];
 
             if f_i.is_zero() {
-                inter_result *= mu;
+                if !inter_result.is_zero() {
+                    inter_result *= mu;
+                }
                 continue;
             }
 


### PR DESCRIPTION
Skips more multiplications in `g2` sumcheck combine fn. Performs 37-38% better for current folding benches.