### PR TITLE
Revert `mul_unchecked()` in Ajtai commit

### DIFF
--- a/latticefold/src/commitment/commitment_scheme.rs
+++ b/latticefold/src/commitment/commitment_scheme.rs
@@ -75,9 +75,7 @@ impl<const C: usize, const W: usize, NTT: SuitableRing> AjtaiCommitmentScheme<C,
             .map(|row| {
                 row.iter()
                     .zip(f.iter())
-                    .fold(NTT::zero(), |acc, (row_j, f_j)| {
-                        acc + (*row_j).mul_unchecked(*f_j)
-                    })
+                    .fold(NTT::zero(), |acc, (row_j, f_j)| acc + *row_j * f_j)
             })
             .collect();
 


### PR DESCRIPTION
While `mul_unchecked()` can provide 2-3% better performance in the Ajtai benches, it actually makes the decomposition benches run about ~3x slower.