### PR TITLE
Move review

### DIFF
--- a/latticefold/src/nifs/folding.rs
+++ b/latticefold/src/nifs/folding.rs
@@ -92,7 +92,7 @@ impl<NTT: SuitableRing, T: TranscriptWithShortChallenges<NTT>> LFFoldingProver<N
     }
 
     fn get_thetas(
-        f_hat_mles: &Vec<Vec<DenseMultilinearExtension<NTT>>>,
+        f_hat_mles: &[Vec<DenseMultilinearExtension<NTT>>],
         r_0: &[NTT],
     ) -> Result<Vec<Vec<NTT>>, FoldingError<NTT>> {
         let theta_s: Vec<Vec<NTT>> = cfg_iter!(f_hat_mles)
@@ -193,7 +193,7 @@ impl<NTT: SuitableRing, T: TranscriptWithShortChallenges<NTT>> FoldingProver<NTT
 
         // Step 6 compute v0, u0, y0, x_w0
         let (v_0, cm_0, u_0, x_0) =
-            compute_v0_u0_x0_cm_0(rho_s_coeff, rho_s, &theta_s, cm_i_s, &eta_s, ccs);
+            compute_v0_u0_x0_cm_0(&rho_s_coeff, &rho_s, &theta_s, cm_i_s, &eta_s, ccs);
 
         // Step 7: Compute f0 and Witness_0
         let h = x_0.last().copied().ok_or(FoldingError::IncorrectLength)?;
@@ -366,8 +366,8 @@ impl<NTT: SuitableRing, T: TranscriptWithShortChallenges<NTT>> FoldingVerifier<N
 
         // Step 6
         let (v_0, cm_0, u_0, x_0) = compute_v0_u0_x0_cm_0(
-            rho_s_coeff,
-            rho_s,
+            &rho_s_coeff,
+            &rho_s,
             &proof.theta_s,
             cm_i_s,
             &proof.eta_s,

--- a/latticefold/src/nifs/folding/tests/mod.rs
+++ b/latticefold/src/nifs/folding/tests/mod.rs
@@ -521,7 +521,7 @@ fn test_prepare_public_output() {
 
     let (rho_s_coeff, rho_s) = get_rhos::<_, _, DP>(&mut transcript);
     let (v_0, cm_0, u_0, x_0) =
-        compute_v0_u0_x0_cm_0(rho_s_coeff, rho_s, &theta_s, &lccs, &eta_s, &ccs);
+        compute_v0_u0_x0_cm_0(&rho_s_coeff, &rho_s, &theta_s, &lccs, &eta_s, &ccs);
     let expected_x_0 = x_0[0..x_0.len() - 1].to_vec();
     let h = x_0.last().copied().unwrap();
 

--- a/latticefold/src/nifs/folding/utils.rs
+++ b/latticefold/src/nifs/folding/utils.rs
@@ -256,14 +256,14 @@ pub(super) fn compute_sumcheck_claim_expected_value<NTT: Ring, P: DecompositionP
 }
 
 pub(super) fn compute_v0_u0_x0_cm_0<const C: usize, NTT: SuitableRing>(
-    rho_s_coeff: Vec<NTT::CoefficientRepresentation>,
-    rho_s: Vec<NTT>,
+    rho_s_coeff: &[NTT::CoefficientRepresentation],
+    rho_s: &[NTT],
     theta_s: &[Vec<NTT>],
     cm_i_s: &[LCCCS<C, NTT>],
     eta_s: &[Vec<NTT>],
     ccs: &CCS<NTT>,
 ) -> (Vec<NTT>, Commitment<C, NTT>, Vec<NTT>, Vec<NTT>) {
-    let v_0: Vec<NTT> = rot_lin_combination(&rho_s_coeff, theta_s);
+    let v_0: Vec<NTT> = rot_lin_combination(rho_s_coeff, theta_s);
 
     let cm_0: Commitment<C, NTT> = rho_s
         .iter()

--- a/latticefold/src/utils/sumcheck.rs
+++ b/latticefold/src/utils/sumcheck.rs
@@ -96,11 +96,8 @@ impl<R: OverField, T: Transcript<R>> MLSumcheck<R, T> {
         for i in 0..nvars {
             let prover_msg = proof.0.get(i).expect("proof is incomplete");
             transcript.absorb_slice(&prover_msg.evaluations);
-            let verifier_msg = IPForMLSumcheck::verify_round(
-                (*prover_msg).clone(),
-                &mut verifier_state,
-                transcript,
-            );
+            let verifier_msg =
+                IPForMLSumcheck::verify_round(prover_msg.clone(), &mut verifier_state, transcript);
             transcript.absorb(&verifier_msg.randomness.into());
         }
 


### PR DESCRIPTION
Found nothing worth changing so far in the public interfaces :+1:

Tried implementing a [mutating `evaluate()`](https://github.com/NethermindEth/lattirust/blob/main/poly/src/mle/dense.rs#L31) to avoid creating a new MLE spawned in `fixed_variables()[0]`, though functions which would use this mutating method would need to clone the MLEs first (or even larger structs for simplicity), causing some performance loss.

Also tried creating a new `DenseMLE::from_vec` method, similar to `from_slice`, though possibly avoiding an allocation. For example to be applied [here](https://github.com/NethermindEth/latticefold/blob/b343d97edc03a7561b5bace14ab159181b3a919e/latticefold/src/nifs/decomposition.rs#L258). However the resizing required for the resulting MLE evaluations length to match 2^nvars, means that we always (or most of the time) need to re-allocate the input vector. Resulting in no performance difference.

Let me know guys if you think I missed anything, the codebase is not small 😄 