### PR TITLE
ci: Relax MSIS typo warning

### DIFF
--- a/.github/workflows/typos.toml
+++ b/.github/workflows/typos.toml
@@ -2,3 +2,5 @@
 extend-ignore-re = [
     "0x.*_i128",
 ]
+[default.extend-words]
+MSIS = "MSIS"


### PR DESCRIPTION
False positive:
```sh
error: `MSIS` should be `MSIS`
  --> ./latticefold/src/decomposition_parameters.rs:12:13
   |
12 |     /// The MSIS bound.
   |             ^^^^
   |
error: `MSIS` should be `MSIS`
  --> ./latticefold/src/decomposition_parameters.rs:33:12
   |
33 |     // The MSIS bound.
   |            ^^^^
   |
```