### PR TITLE
ci: Fix clippy on generated bench code

### DIFF
--- a/latticefold/build.rs
+++ b/latticefold/build.rs
@@ -463,7 +463,7 @@ fn write_ajtai_group(file: &mut File, benchmarks: &[AjtaiRecord], name: &str, ri
                         );
                     },
                 );
-            }
+            };
         }
     }).collect();
 
@@ -585,13 +585,13 @@ fn write_function(
                     {
                         if ENV.prover {
                             BlockBencher::#prover_function(&mut group, #scalar);
-                        }
+                        };
 
                         if ENV.verifier {
                             BlockBencher::#verifier_function(&mut group, #scalar);
-                        }
+                        };
                     }
-                }
+                };
             }
         })
         .collect();


### PR DESCRIPTION
Clippy failing on analyzing generated code,

```sh
error: this looks like an `else if` but the `else` is missing
 --> /home/runner/work/latticefold/latticefold/target/debug/build/latticefold-77a91d4d84be390a/out/generated_e2e_benchmarks.rs:3:1302
  |
3 | ...ncher :: bench_e2e_verifier (& mut group , R1CS :: Scalar) ; } } } if ENV . e2e && ENV . GoldilocksRingNTT { const X_LEN : usize = 1us...
  |                                                                      ^
  |
  = note: to remove this lint, add the missing `else` or add a new line before the second `if`
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#suspicious_else_formatting
  = note: `-D clippy::suspicious-else-formatting` implied by `-D warnings`
  = help: to override `-D warnings` add `#[allow(clippy::suspicious_else_formatting)]`
```