### PR TITLE
Relax lints on lf+ benches

### DIFF
--- a/crates/latticefold-plus/benches/decomp.rs
+++ b/crates/latticefold-plus/benches/decomp.rs
@@ -49,17 +49,18 @@ use utils::{
 // Setup Functions
 // ============================================================================
 
+/// Decomposition input for prover benchmarks
+struct SetupInput {
+    decomp: Decomp<R>,
+    B: usize,
+}
+
 /// Creates decomposition input for prover benchmarks.
 ///
 /// Generates a LinB2 instance by first creating a committed R1CS, linearizing
 /// it, and then preparing the decomposition input structure. Uses witness with
 /// all ones to ensure valid R1CS satisfaction and norm bounds.
-fn setup_input(
-    n: usize,
-    k: usize,
-    kappa: usize,
-    B: usize,
-) -> (Decomp<R>, Vec<R>, Vec<(R, R)>, usize) {
+fn setup_input(n: usize, k: usize, kappa: usize, B: usize) -> SetupInput {
     let mut rng = bench_rng();
     let r1cs = R1CSBuilder::new(n, k, B as u128).build_basic();
     let r1cs = r1cs_decomposed_square(r1cs, n, B as u128, k);
@@ -69,7 +70,7 @@ fn setup_input(
     let cr1cs = ComR1CS::new(r1cs, z, 1, B as u128, k, &A);
 
     let mut ts = create_transcript();
-    let (linb, lproof) = cr1cs.linearize(&mut ts);
+    let (_linb, lproof) = cr1cs.linearize(&mut ts);
 
     let mut ts = create_transcript();
     lproof.verify(&mut ts);
@@ -80,7 +81,15 @@ fn setup_input(
         M: cr1cs.x.matrices(),
     };
 
-    (decomp, cr1cs.x.cm_f, linb.x.v, B)
+    SetupInput { decomp, B }
+}
+
+/// Decomposition proof for verifier benchmarks
+struct SetupProof {
+    cm_f: Vec<R>,
+    v: Vec<(R, R)>,
+    B: usize,
+    proof: DecompProof<R>,
 }
 
 /// Generates a valid decomposition proof for verifier benchmarks.
@@ -88,12 +97,7 @@ fn setup_input(
 /// Creates a LinB2 instance, executes the decomposition protocol to generate
 /// a `DecompProof`, and validates it before returning. This ensures the
 /// verifier benchmarks measure only verification time, not error handling.
-fn setup_proof(
-    n: usize,
-    k: usize,
-    kappa: usize,
-    B: usize,
-) -> ((Vec<R>, Vec<(R, R)>, usize), DecompProof<R>) {
+fn setup_proof(n: usize, k: usize, kappa: usize, B: usize) -> SetupProof {
     let mut rng = bench_rng();
     let r1cs = R1CSBuilder::new(n, k, B as u128).build_basic();
     let r1cs = r1cs_decomposed_square(r1cs, n, B as u128, k);
@@ -119,7 +123,12 @@ fn setup_proof(
 
     proof.verify(&cr1cs.x.cm_f, &linb.x.v, B as u128);
 
-    ((cr1cs.x.cm_f, linb.x.v, B), proof)
+    SetupProof {
+        cm_f: cr1cs.x.cm_f,
+        v: linb.x.v,
+        B,
+        proof,
+    }
 }
 
 // ============================================================================
@@ -144,7 +153,7 @@ impl ProverBenchmark for DecompositionProver {
 
     fn setup_input((n, k, kappa, B): Self::Params) -> Self::Input {
         let mut rng = bench_rng();
-        let (decomp, _cm_f, _v, B) = setup_input(n, k, kappa, B);
+        let SetupInput { decomp, B, .. } = setup_input(n, k, kappa, B);
         let A = create_ajtai_matrix(kappa, n, &mut rng);
         (decomp, A, B)
     }
@@ -179,7 +188,8 @@ impl VerifierBenchmark for DecompositionVerifier {
     }
 
     fn setup_proof((n, k, kappa, B): Self::Params) -> (Self::Input, Self::Proof) {
-        setup_proof(n, k, kappa, B)
+        let sp = setup_proof(n, k, kappa, B);
+        ((sp.cm_f, sp.v, sp.B), sp.proof)
     }
 
     fn param_label((n, k, kappa, B): Self::Params) -> String {
@@ -228,7 +238,7 @@ fn bench_decomp_roundtrip(c: &mut Criterion) {
             bencher.iter_batched(
                 || {
                     let mut rng = bench_rng();
-                    let (decomp, _cm_f, _v, B) = setup_input(n, k, kappa, B);
+                    let SetupInput { decomp, B, .. } = setup_input(n, k, kappa, B);
                     let A = create_ajtai_matrix(kappa, n, &mut rng);
                     (decomp, A, B)
                 },

--- a/crates/latticefold-plus/benches/double_commitment.rs
+++ b/crates/latticefold-plus/benches/double_commitment.rs
@@ -26,7 +26,9 @@
 
 use criterion::Criterion;
 use latticefold_plus::{
-    r1cs::ComR1CS, rgchk::{DecompParameters, RgInstance}, utils::estimate_bound,
+    r1cs::ComR1CS,
+    rgchk::{DecompParameters, RgInstance},
+    utils::estimate_bound,
 };
 use stark_rings::{cyclotomic_ring::models::frog_ring::RqPoly as R, PolyRing};
 use stark_rings_linalg::Matrix;

--- a/crates/latticefold-plus/benches/e2e.rs
+++ b/crates/latticefold-plus/benches/e2e.rs
@@ -27,7 +27,6 @@
 #![allow(non_snake_case)]
 
 use criterion::Criterion;
-use cyclotomic_rings::rings::FrogPoseidonConfig as PC;
 use latticefold_plus::{
     lin::LinParameters,
     plus::{PlusParameters, PlusProof, PlusProver, PlusVerifier},

--- a/crates/latticefold-plus/benches/lin.rs
+++ b/crates/latticefold-plus/benches/lin.rs
@@ -58,7 +58,7 @@ use utils::{
 /// ensure valid R1CS satisfaction with norm bound B.
 fn setup_input(n: usize, k: usize, kappa: usize, B: usize) -> LinB<R> {
     let mut rng = bench_rng();
-    let dparams = get_validated_decomp_params(k, kappa, n);
+    let _dparams = get_validated_decomp_params(k, kappa, n);
 
     let r1cs = R1CSBuilder::new(n, k, B as u128).build_decomposed_square();
     let A = create_ajtai_matrix(kappa, n, &mut rng);
@@ -96,7 +96,7 @@ fn setup_proof(
     let A = create_ajtai_matrix(kappa, n, &mut rng);
 
     let mut ts = create_transcript();
-    let (linb2, proof) = linb.lin(&A, &M, &params, &mut ts);
+    let (_linb2, proof) = linb.lin(&A, &M, &params, &mut ts);
 
     let mut verify_ts = create_transcript();
     proof

--- a/crates/latticefold-plus/benches/mlin.rs
+++ b/crates/latticefold-plus/benches/mlin.rs
@@ -115,7 +115,7 @@ fn setup_proof(
 
     let A = create_ajtai_matrix(kappa, n, &mut rng);
     let mut ts = create_transcript();
-    let (linb2, proof) = mlin.mlin(&A, &M, &mut ts);
+    let (_linb2, proof) = mlin.mlin(&A, &M, &mut ts);
 
     let mut verify_ts = create_transcript();
     proof

--- a/crates/latticefold-plus/benches/utils/helpers.rs
+++ b/crates/latticefold-plus/benches/utils/helpers.rs
@@ -94,7 +94,7 @@ impl WitnessPattern {
                 let choices = [R::ZERO, R::ONE];
                 (0..size).map(|_| *choices.choose(rng).unwrap()).collect()
             }
-            WitnessPattern::Custom(f) => (0..size).map(|i| f(i)).collect(),
+            WitnessPattern::Custom(f) => (0..size).map(f).collect(),
         }
     }
 }
@@ -311,7 +311,7 @@ pub fn bench_prover_protocol<P: ProverBenchmark>(c: &mut Criterion, param_sets: 
         group.throughput(Throughput::Elements(P::throughput(params)));
 
         group.bench_with_input(
-            BenchmarkId::from_parameter(&P::param_label(params)),
+            BenchmarkId::from_parameter(P::param_label(params)),
             &params,
             |bencher, &params| {
                 bencher.iter_batched(
@@ -345,7 +345,7 @@ pub fn bench_verifier_protocol<V: VerifierBenchmark>(c: &mut Criterion, param_se
         group.throughput(Throughput::Elements(V::throughput(params)));
 
         group.bench_with_input(
-            BenchmarkId::from_parameter(&V::param_label(params)),
+            BenchmarkId::from_parameter(V::param_label(params)),
             &params,
             |bencher, &params| {
                 let (input, proof) = V::setup_proof(params);
@@ -470,8 +470,6 @@ pub fn get_validated_decomp_params(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     #[test]
     fn test_bench_rng_deterministic() {
         let mut rng1 = bench_rng();

--- a/crates/latticefold-plus/benches/utils/mod.rs
+++ b/crates/latticefold-plus/benches/utils/mod.rs
@@ -10,6 +10,9 @@
 //! - `KAPPA_SCALING`: Varies security parameter κ (kappa)
 //! - `FOLDING_ARITY`: Varies number of instances L for batched protocols
 
+// suppress warnings given that types here are used in all benches
+#![allow(dead_code)]
+
 pub mod helpers;
 
 /// Range check protocol (Constructions 4.3-4.4) parameter sets.
@@ -237,11 +240,8 @@ pub mod double_commitment {
     /// - L: Folding arity (affects bound calculation)
     /// - k: Decomposition width (gadget decomposition parameter)
     /// - kappa: Security parameter (commitment matrix rows)
-    pub const WITNESS_SCALING: &[(usize, usize, usize, usize)] = &[
-        (32768, 3, 2, 2),
-        (65536, 3, 4, 2),
-        (131072, 3, 4, 2),
-    ];
+    pub const WITNESS_SCALING: &[(usize, usize, usize, usize)] =
+        &[(32768, 3, 2, 2), (65536, 3, 4, 2), (131072, 3, 4, 2)];
 
     /// Decomposition width scaling benchmark.
     ///
@@ -252,10 +252,7 @@ pub mod double_commitment {
     /// Fixed parameters: L=3, κ=2.
     ///
     /// Format: `(n, L, k, kappa)`
-    pub const K_SCALING: &[(usize, usize, usize, usize)] = &[
-        (65536, 3, 2, 2),
-        (65536, 3, 4, 2),
-    ];
+    pub const K_SCALING: &[(usize, usize, usize, usize)] = &[(65536, 3, 2, 2), (65536, 3, 4, 2)];
 }
 
 /// End-to-end LatticeFold+ protocol parameter sets.
@@ -279,11 +276,8 @@ pub mod e2e {
     /// - L: Folding arity (number of R1CS instances to batch)
     /// - k: Decomposition width
     /// - kappa: Security parameter
-    pub const PROTOCOL_SCALING: &[(usize, usize, usize, usize)] = &[
-        (65536, 2, 4, 2),
-        (65536, 3, 4, 2),
-        (131072, 3, 4, 2),
-    ];
+    pub const PROTOCOL_SCALING: &[(usize, usize, usize, usize)] =
+        &[(65536, 2, 4, 2), (65536, 3, 4, 2), (131072, 3, 4, 2)];
 
     /// Folding arity scaling benchmark.
     ///


### PR DESCRIPTION
Relax clippy. Mainly due to dead-code warnings caused by different benches using the same common utils/helpers code.